### PR TITLE
Task | ENG-180 | E2E TEST | footer

### DIFF
--- a/cypress/e2e/footer/email-form.cy.js
+++ b/cypress/e2e/footer/email-form.cy.js
@@ -1,0 +1,17 @@
+Cypress.env('viewports').forEach((viewport) => {
+	describe(`Footer email form: ${viewport.device} (${viewport.width} x ${viewport.height})`, () => {
+		beforeEach(() => {
+			cy.viewport(viewport.width, viewport.height)
+            cy.visit(Cypress.env('baseURL'))
+            cy.closeAttn()
+		})
+        it('I can enter my email in the signup form and see a success message', function () {
+            cy.fixture('user-login').then((user) => {
+                this.user = user
+                cy.get('input.footer-input').type(this.user.email)
+                cy.get('button.footer-button').find('svg').click()
+            })
+            cy.get('#footer-input-email_msg').should('not.be.empty')
+        })
+	})
+})

--- a/cypress/e2e/footer/icons.cy.js
+++ b/cypress/e2e/footer/icons.cy.js
@@ -1,0 +1,62 @@
+Cypress.env('viewports').forEach((viewport) => {
+	describe(`Footer icons: ${viewport.device} (${viewport.width} x ${viewport.height})`, () => {
+		beforeEach(() => {
+			cy.viewport(viewport.width, viewport.height)
+            cy.visit(Cypress.env('baseURL'))
+            cy.closeAttn()
+		})
+        it('I can click the TikTok icon and be forwarded to the Dolls Kill TikTok page', () => {
+            cy.get('#footer-socials').find('a').first().as('tiktok')
+            cy.get('@tiktok').invoke('attr', 'href').then((url) => {
+                cy.get('@tiktok').invoke('removeAttr', 'target').click()
+                cy.origin(url, { args: { url } }, ({ url }) => {
+                    cy.url().should('include', url)
+                    cy.go('back')
+                })
+            })
+        })
+        it('I can click the Instagram icon and be forwarded to the Dolls Kill Instagram page', () => {
+            cy.get('#footer-socials').find('a').eq(1).as('ig')
+            cy.get('@ig').invoke('attr', 'href').then((url) => {
+                cy.get('@ig').invoke('removeAttr', 'target').click()
+                cy.origin(url, { args: { url } }, ({ url }) => {
+                    cy.url().should('include', url)
+                    cy.go('back')
+                })
+            })
+        })
+        it('I can click the Apple App Store download icon and be forwarded to the right url', () => {
+            if (viewport.width < Cypress.env('mobileBreak')) {
+                cy.get('.footer-mobile-app-links-sm-only').find('a').first().as('apple')
+            } else {
+                cy.get('.footer-mobile-app-links-lg-only').find('a').first().as('apple')
+            }
+            cy.get('@apple').invoke('attr', 'href').then((url) => {
+                const splitURL = url.split('/')
+                let domain = splitURL[2]
+                cy.get('@apple').invoke('removeAttr', 'target').click()
+                cy.origin(domain, { args: { domain, url } }, ({ domain, url }) => {
+                    cy.url().should('include', url)
+                    cy.go('back')
+                })
+            })
+        })
+
+        it('I can click the Google Play Store download icon and be forwarded to the right url', () => {
+            if (viewport.width < Cypress.env('mobileBreak')) {
+                cy.get('.footer-mobile-app-links-sm-only').find('a').eq(1).as('google')
+            } else {
+                cy.get('.footer-mobile-app-links-lg-only').find('a').eq(1).as('google')
+            }
+            cy.get('@google').invoke('attr', 'href').then((url) => {
+                const splitURL = url.split('/')
+                let domain = splitURL[2]
+                cy.get('@google').invoke('removeAttr', 'target').click()
+                cy.origin(domain, { args: { domain, url } }, ({ domain, url }) => {
+                    cy.url().should('include', url)
+                    cy.go('back')
+                })
+            })
+        })
+	})
+})

--- a/cypress/e2e/footer/legal.cy.js
+++ b/cypress/e2e/footer/legal.cy.js
@@ -1,0 +1,36 @@
+Cypress.env('viewports').forEach((viewport) => {
+	describe(`Footer legal: ${viewport.device} (${viewport.width} x ${viewport.height})`, () => {
+		beforeEach(() => {
+			cy.viewport(viewport.width, viewport.height)
+			cy.visit(Cypress.env('baseURL'))
+			cy.closeAttn()
+		})
+		it('I can click on all of the legal links and be forwarded to the right pages', () => {
+			const pages = [
+				{ linkText: 'Privacy Policy', header: 'Privacy Policy', url: '/pages/privacy-policy' },
+				{ linkText: 'Terms Of Use', header: 'Terms of Use', url: '/pages/termsofuse' },
+				{ linkText: 'Cookie Policy', header: 'Cookie Policy', url: '/pages/cookie-policy' },
+				{ linkText: 'Accessibility', header: 'Accessibility', url: '/pages/accessibility' },
+			]
+			pages.forEach((page) => {
+				cy.get('#footer-legal').find('a').contains(page.linkText).click()
+				if (page.external === true) {
+					const pageURL = page.url
+					cy.origin(pageURL, { args: { pageURL } }, ({ pageURL }) => {
+						cy.url().should('include', pageURL)
+						cy.go('back')
+					})
+				} else if (page.header === '') {
+					cy.url().should('include', page.url)
+					cy.go('back')
+				} else {
+					cy.get('h1').contains(page.header).should('exist')
+					cy.go('back')
+				}
+			})
+		})
+		it('The copyright text reads as it should', () => {
+			cy.get('.footer-item-10').contains('Copyright © 2023 dollskill.com. All Rights Reserved.').should('be.visible')
+		})
+	})
+})

--- a/cypress/e2e/footer/main-links.cy.js
+++ b/cypress/e2e/footer/main-links.cy.js
@@ -1,0 +1,97 @@
+Cypress.env('viewports').forEach((viewport) => {
+	describe(`Footer links: ${viewport.device} (${viewport.width} x ${viewport.height})`, () => {
+		beforeEach(() => {
+			cy.viewport(viewport.width, viewport.height)
+			cy.visit(Cypress.env('baseURL'))
+			cy.closeAttn()
+		})
+		it('All of the links under ACCOUNT forward me to the correct page', function () {
+			const pages = [
+				{ linkText: 'Order Status', header: 'Order Status', url: 'help.dollskill.com/order-problems/order-status' },
+				{ linkText: 'My Account', header: 'My Account', url: '/account' },
+				{ linkText: 'Favorites', header: 'Wishlist', url: '/pages/wishlist' },
+				{ linkText: 'Start A Return', header: '', url: '/apps/returns' },
+			]
+			cy.get('.footer-title').contains('Account').click()
+			cy.get('[data-target="Account"]').find('a.footer-item').contains('My Account').click()
+			cy.fixture('user-login').then((user) => {
+				this.user = user
+				cy.get('.account-login').find('input[type="email"]').type(this.user.email)
+				cy.get('button.login-button').click()
+				cy.get('.account-login').find('input[type="password"]').type(this.user.password)
+				cy.get('button.login-button').click()
+			})
+			cy.get('[data-header-logo]').click()
+			pages.forEach((page) => {
+				cy.get('.footer-title').contains('Account').click()
+				cy.get('a.footer-item').not('.tw-hidden').contains(page.linkText).click()
+				if (page.external === true) {
+					const pageURL = page.url
+					cy.origin(pageURL, { args: { pageURL } }, ({ pageURL }) => {
+						cy.url().should('include', pageURL)
+						cy.go('back')
+					})
+				} else if (page.header === '') {
+					cy.url().should('include', page.url)
+					cy.go('back')
+				} else {
+					cy.get('h1').contains(page.header).should('exist')
+					cy.go('back')
+				}
+			})
+		})
+		it('All of the links under HELP forward me to the correct page', function () {
+			const pages = [
+				{ linkText: 'FAQ', header: 'Customer Service', url: 'help.dollskill.com' },
+				{ linkText: 'Shipping Info', header: 'Shipping Information', url: 'help.dollskill.com/shipping-delivery/shipping-information' },
+				{ linkText: 'Returns & Exchanges', header: 'Returns', url: 'help.dollskill.com/returns' },
+				{ linkText: 'Payments', header: 'Payments & Promos', url: 'help.dollskill.com/payments-promos' },
+				{ linkText: 'Customer Service', header: 'Customer Service', url: 'help.dollskill.com' },
+			]
+			pages.forEach((page) => {
+				cy.get('.footer-title').contains('Help').click()
+				cy.get('a.footer-item').not('.tw-hidden').contains(page.linkText).click()
+                if (page.external === true) {
+					const pageURL = page.url
+					cy.origin(pageURL, { args: { pageURL } }, ({ pageURL }) => {
+						cy.url().should('include', pageURL)
+						cy.go('back')
+					})
+				} else if (page.header === '') {
+					cy.url().should('include', page.url)
+					cy.go('back')
+				} else {
+					cy.get('h1').contains(page.header).should('exist')
+					cy.go('back')
+				}
+			})
+		})
+		it('All of the links under ABOUT forward me to the correct page', function () {
+			const pages = [
+				{ linkText: 'About', header: '', url: '/pages/about' },
+				{ linkText: 'Store Locations', header: '', url: '/pages/store-locations' },
+				{ linkText: 'Size Guide', header: 'Size Guide', url: 'help.dollskill.com/product-stock/size-guide' },
+				{ linkText: 'Careers', header: '', url: 'jobs.lever.co/dollskill', external: true },
+				{ linkText: 'Gift Cards', header: 'Dolls Kill Gift Cards', url: '/collections/gift-cards' },
+				{ linkText: 'App', header: '', url: '/pages/app' },
+			]
+			pages.forEach((page) => {
+				cy.get('.footer-title').contains('About').click()
+				cy.get('a.footer-item').not('.tw-hidden').contains(page.linkText).click()
+				if (page.external === true) {
+					const pageURL = page.url
+					cy.origin(pageURL, { args: { pageURL } }, ({ pageURL }) => {
+						cy.url().should('include', pageURL)
+						cy.go('back')
+					})
+				} else if (page.header === '') {
+					cy.url().should('include', page.url)
+					cy.go('back')
+				} else {
+					cy.get('h1').contains(page.header).should('exist')
+					cy.go('back')
+				}
+			})
+		})
+	})
+})

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "cy:run": "cypress run",
     "cy:run:nav": "cypress run --spec cypress/e2e/navigation",
     "cy:run:cart": "cypress run --spec cypress/e2e/addToCart",
-    "cy:run:quick": "cypress run --spec cypress/e2e/addToCart/quickAdd.cy.js"
+    "cy:run:quick": "cypress run --spec cypress/e2e/addToCart/quickAdd.cy.js",
+    "cy:run:footer": "cypress run --spec cypress/e2e/footer"
   },
   "author": "Celina Oh",
   "license": "ISC",


### PR DESCRIPTION
E2E test for:

- footer links
- footer email form
- footer legal links
- footer copyright msg
- footer social links
- footer app download links

Notes:

- If any links are added to the footer, I'll have to update the script and add it as an object in the array (I can't click on each link in a selected element because once the page is updated, the element is detached and throws an error)
- Some links have text that don't match the header of the page (ex "Favorites" link > "Wishlist" header)
- If I can't pull an H1 from the page, I'm matching the URL (ex the H1 on the Start A Return page is in an iframe)
- If the link is external, I have to wrap in cy.origin and am matching the URL
- I can do a for loop (similar to the footer links) once data tags are added, or keep it as is (I think it's fine now since we only have TikTok and IG, but before we had like 5 or 6 and not sure if we plan on adding/changing those)